### PR TITLE
Ensure graceful closure of stunnel

### DIFF
--- a/bin/run-stunnel
+++ b/bin/run-stunnel
@@ -1,74 +1,18 @@
 #!/usr/bin/env bash
 
-main() {
-  at stunnel-enabled
-  run-stunnel "$@"
-}
+source start-stunnel
 
 run-stunnel() {
-  declare sentinel=/tmp/stunnel-buildpack-wait
   declare -A pids signals
 
   config-gen
-
-  # Use named pipe to detect exit of any subprocess.
-  rm -f "$sentinel"
-  mkfifo "$sentinel"
+  setup-sentinel
 
   # Start processes.
   aux-start stunnel SIGINT stunnel4 vendor/stunnel/stunnel.conf
-  exec "$@"
-}
+  "$@"
 
-config-gen() {
-  # Generate config files
-  at config-gen-start
-  source bin/stunnel-conf.sh
-  at config-gen-end
-
-  # Overwrite config vars with stunnel targets
-  URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS | grep -v STUNNEL`}
-
-  for URL in $URLS; do
-    at "config-gen-override $URL"
-    eval "$URL=\$${URL}_STUNNEL"
-  done
-}
-
-aux-start() {
-  declare name=$1 signal=$2
-  shift 2
-
-  (
-    at "$name-start"
-
-    # Ignore SIGTERM; this is inherited by the child process.
-    trap '' SIGTERM
-
-    # Start child in the background.
-    "$@" &
-
-    # Translate SIGHUP to the appropriate signal to stop the child (anything
-    # except SIGTERM which is ignored). This *will* cancel the wait and may
-    # lead to the outer subshell exiting before the aux process
-    trap "kill -$signal $!" SIGHUP
-
-    # Wait for child to finish, either by crash or by $signal
-    wait
-
-    # Notify FIFO if this finishes first
-    echo "$name" > "$psmgr"
-
-    at "$name-end"
-  ) &
-
-  pids[$name]=$!
-  signals[$name]=$signal
-  at "$name-launched pid=$! signal=$signal"
-}
-
-at() {
-  echo "buildpack=stunnel at=$*"
+  cleanup
 }
 
 [[ "$0" != "$BASH_SOURCE" ]] || main "$@"

--- a/bin/start-stunnel
+++ b/bin/start-stunnel
@@ -10,15 +10,30 @@ main() {
   run-stunnel "$@"
 }
 
-run-stunnel() {
-  declare sentinel=/tmp/stunnel-buildpack-wait
-  declare -A pids signals
-
-  config-gen
-
+setup-sentinel() {
+  sentinel=$(mktemp)
   # Use named pipe to detect exit of any subprocess.
   rm -f "$sentinel"
   mkfifo "$sentinel"
+}
+
+cleanup() {
+  rm -f "$sentinel"
+  # Kill the auxiliary processes.
+  # Send each one SIGHUP which will be translated by the trap in aux-start.
+  declare name
+  for name in "${!pids[@]}"; do
+    at "kill-aux name=$name pid=${pids[$name]} signal=${signals[$name]}"
+    kill -SIGHUP "${pids[$name]}"
+  done
+
+  wait
+}
+
+run-stunnel() {
+  declare -A pids signals
+  config-gen
+  setup-sentinel
 
   # Start processes.
   aux-start stunnel SIGINT stunnel4 vendor/stunnel/stunnel.conf
@@ -52,13 +67,7 @@ run-stunnel() {
   at "wait-app pid=$pid"
   wait $pid
 
-  # Kill the auxiliary processes.
-  # Send each one SIGHUP which will be translated by the trap in aux-start.
-  declare name
-  for name in "${!pids[@]}"; do
-    at "kill-aux name=$name pid=${pids[$name]} signal=${signals[$name]}"
-    kill -SIGHUP "${pids[$name]}"
-  done
+  cleanup
 }
 
 config-gen() {
@@ -66,14 +75,6 @@ config-gen() {
   at config-gen-start
   source bin/stunnel-conf.sh
   at config-gen-end
-
-  # Overwrite config vars with stunnel targets
-  URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS | grep -v STUNNEL`}
-
-  for URL in $URLS; do
-    at "config-gen-override $URL"
-    eval "$URL=\$${URL}_STUNNEL"
-  done
 }
 
 aux-start() {
@@ -92,7 +93,7 @@ aux-start() {
     # Translate SIGHUP to the appropriate signal to stop the child (anything
     # except SIGTERM which is ignored). This *will* cancel the wait and may
     # lead to the outer subshell exiting before the aux process
-    trap "kill -$signal $!" SIGHUP
+    trap "kill-with-timeout  -${signal} $! 3" SIGHUP
 
     # Wait for child to finish, either by crash or by $signal
     wait
@@ -123,7 +124,8 @@ app-start() {
     # Translate SIGHUP to the appropriate signal to stop the child
     # (probably SIGTERM in this case). This *will* cancel the wait and may
     # lead to the outer subshell exiting before the app.
-    trap "kill -$signal $!" SIGHUP
+
+    trap "kill-with-timeout -${signal} $! 3" SIGHUP
 
     # Ignore SIGTERM because the dyno will broadcast it to all children --
     # there is no need to translate it.
@@ -143,6 +145,25 @@ app-start() {
 
 at() {
   echo "buildpack=stunnel at=$*"
+}
+
+kill-with-timeout() {
+    signal=${1}
+    victim=${2}
+    timeout=${3}
+
+    started_at=$(date +"%s") # current UNIX timestamp
+    timout_at=$((${started_at} + ${timeout}))
+
+    while true ; do
+      kill ${signal} ${victim} || break
+
+      sleep 0.1
+
+      [[ $(date +"%s") -gt ${timout_at} ]] && break
+    done
+
+    kill -0 ${victim} && kill -SIGKILL ${victim}
 }
 
 is-enabled() {


### PR DESCRIPTION
Most of the run-stunnel script is also present in the start-stunnel
script.  This change reuses this code.

It also ensures that the aux (i.e. stunnel) job that is created by both scripts
is terminated.  It first  attempts to send a SIGINT (as it did previously),
however if after 3 seconds the process has not terminated it instead
sends a SIGKILL.

This ensures that there are not dangling stunnel processes left over after the
script is run and that repeated executions of the script will have predicatable
results.

### Verification

#### Proof of the issue

- Use the master branch of this buildpack in develop (i.e. set `https://github.com/kalohq/heroku-buildpack-stunnel.git` as the buildpack for `heroku-lotus-develop` via the web interface)
- create a new one-off instance running `bash`: `heroku run -r develop bash` (This assumes you have set up `heroku-lotus-develop` as a git remote called `develop`.
- invoke `start-stunnel true`
- invoke `ps -ef`, a `stunnel` process should be visible:
```
UID        PID  PPID  C STIME TTY          TIME CMD
nobody       1     0  0 09:44 ?        00:00:00 ps-run
u36281       4     1  0 09:44 ?        00:00:00 bash
u36281      24     1  0 09:44 ?        00:00:00 stunnel4 vendor/stunnel/stunnel.conf
u36281      28     4  0 09:44 ?        00:00:00 ps -ef
```
- invoke `start-stunnel true` agina.
- You should see errors saying that stunnel was unable to bind the `POSTGRES` service.
```
[.] Configuration successful
[ ] Binding service [POSTGRES]
[ ] Listening file descriptor created (FD=7)
[ ] Option SO_REUSEADDR set on accept socket
[!] bind: Address already in use (98)
[!] Error binding service [POSTGRES] to 127.0.0.1:6371
[ ] Unbinding service [POSTGRES]
```

#### The solution

- Use this branch as the buildpack for develop (i.e. set `https://github.com/kalohq/heroku-buildpack-stunnel.git/terminate-all-stunnel-subproccesses` [sic] as the buildpack for `heroku-lotus-develop` via the web interface)
- Deploy the app
- create a new one-off instance running `bash`: `heroku run -r develop bash` (This assumes you have set up `heroku-lotus-develop` as a git remote called `develop`.
- invoke `start-stunnel true` (You should see a flurry of Stunnel activity and the process exit successfully)
- invoke `ps -ef`, no `stunnel` processes should be visible.
- invoke `run-stunnel rails c`
- in the console invoke `User.last` (no errors should be seen)
- exit (type `exit` or press `^D`)
- stunnel should exit successfully
- invoke `ps -ef`, no `stunnel` processes should be visible.
